### PR TITLE
Move some code to BitmapRenderer.Draw and SvgRenderer.Draw

### DIFF
--- a/Mapsui.Rendering.Skia/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia/BitmapHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Mapsui.Styles;
 using SkiaSharp;
@@ -7,12 +6,11 @@ namespace Mapsui.Rendering.Skia
 {
     public static class BitmapHelper
     {
-        // The field below is static for performance. Effect has not been measured.
-        // Note that the default FilterQuality is None. Setting it explicitly to Low increases the quality.
-        private static readonly SKPaint DefaultPaint = new SKPaint { FilterQuality = SKFilterQuality.Low }; 
-
         public static BitmapInfo LoadBitmap(object bitmapStream)
         {
+            // todo: Our BitmapRegistry stores not only bitmaps. Perhaps we should store a class in it
+            // which has all information. So we should have a SymbolImageRegistry in which we store a
+            // SymbolImage. Which holds the type, data and other parameters.
             if (bitmapStream is Stream stream)
             {
                 byte[] buffer = new byte[4];
@@ -39,103 +37,6 @@ namespace Mapsui.Rendering.Skia
             }
 
             return null;
-        }
-
-        public static void RenderBitmap(SKCanvas canvas, SKImage bitmap, float x, float y, float rotation = 0,
-            float offsetX = 0, float offsetY = 0,
-            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
-            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-            float opacity = 1f,
-            float scale = 1f)
-        {
-            canvas.Save();
-
-            canvas.Translate(x, y);
-            if (rotation != 0)
-                canvas.RotateDegrees(rotation, 0, 0); // todo: degrees or radians?
-            canvas.Scale(scale, scale);
-
-            var width = bitmap.Width;
-            var height = bitmap.Height;
-
-            x = offsetX + DetermineHorizontalAlignmentCorrection(horizontalAlignment, width);
-            y = -offsetY + DetermineVerticalAlignmentCorrection(verticalAlignment, height);
-
-            var halfWidth = width >> 1;
-            var halfHeight = height >> 1;
-
-            var rect = new SKRect(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
-
-            RenderBitmap(canvas, bitmap, rect, opacity);
-
-            canvas.Restore();
-        }
-
-        public static void RenderSvg(SKCanvas canvas, SkiaSharp.Extended.Svg.SKSvg svg, float x, float y, float orientation = 0,
-            float offsetX = 0, float offsetY = 0,
-            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
-            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
-            float opacity = 1f,
-            float scale = 1f)
-        {
-            canvas.Save();
-
-            canvas.Translate(x, y);
-            canvas.RotateDegrees(orientation, 0, 0); // todo: degrees or radians?
-            canvas.Scale(scale, scale);
-
-            var halfWidth = svg.CanvasSize.Width / 2;
-            var halfHeight = svg.CanvasSize.Height / 2;
-
-            // 0/0 are assumed at center of image, but Svg has 0/0 at left top position
-            canvas.Translate(-halfWidth + offsetX, -halfHeight - offsetY);
-
-            canvas.DrawPicture(svg.Picture, new SKPaint() { IsAntialias = true });
-
-            canvas.Restore();
-        }
-
-        private static int DetermineHorizontalAlignmentCorrection(
-            LabelStyle.HorizontalAlignmentEnum horizontalAlignment, int width)
-        {
-            if (horizontalAlignment == LabelStyle.HorizontalAlignmentEnum.Left) return width >> 1;
-            if (horizontalAlignment == LabelStyle.HorizontalAlignmentEnum.Right) return -(width >> 1);
-            return 0; // center
-        }
-
-        private static int DetermineVerticalAlignmentCorrection(
-            LabelStyle.VerticalAlignmentEnum verticalAlignment, int height)
-        {
-            if (verticalAlignment == LabelStyle.VerticalAlignmentEnum.Top) return -(height >> 1);
-            if (verticalAlignment == LabelStyle.VerticalAlignmentEnum.Bottom) return height >> 1;
-            return 0; // center
-        }
-
-        public static void RenderRaster(SKCanvas canvas, SKImage bitmap, SKRect rect, float layerOpacity)
-        {
-            canvas.DrawImage(bitmap, rect, GetPaint(layerOpacity));
-        }
-
-        private static SKPaint GetPaint(float layerOpacity)
-        {
-            if (Math.Abs(layerOpacity - 1) > Utilities.Constants.Epsilon)
-            {
-                // Unfortunately for opacity we need to set the Color and the Color
-                // is part of the Paint object. So we need to recreate the paint on
-                // every draw. 
-                return new SKPaint
-                {
-                    FilterQuality = SKFilterQuality.Low,
-                    Color = new SKColor(255, 255, 255, (byte) (255 * layerOpacity))
-                };
-            }
-            return DefaultPaint;
-        }
-
-
-        public static void RenderBitmap(SKCanvas canvas, SKImage bitmap, SKRect rect, float opacity = 1f)
-        {
-            canvas.DrawImage(bitmap, rect, GetPaint(opacity));
-        }
+        }     
     }
 }

--- a/Mapsui.Rendering.Skia/BitmapRenderer.cs
+++ b/Mapsui.Rendering.Skia/BitmapRenderer.cs
@@ -1,0 +1,79 @@
+﻿using Mapsui.Styles;
+using SkiaSharp;
+using System;
+
+namespace Mapsui.Rendering.Skia
+{
+    class BitmapRenderer
+    {
+        // The field below is static for performance. Effect has not been measured.
+        // Note that the default FilterQuality is None. Setting it explicitly to Low increases the quality.
+        private static readonly SKPaint DefaultPaint = new SKPaint { FilterQuality = SKFilterQuality.Low };
+        
+        public static void Draw(SKCanvas canvas, SKImage bitmap, SKRect rect, float layerOpacity = 1f)
+        {
+            canvas.DrawImage(bitmap, rect, GetPaint(layerOpacity));
+        }
+
+        public static void Draw(SKCanvas canvas, SKImage bitmap, float x, float y, float rotation = 0,
+            float offsetX = 0, float offsetY = 0,
+            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
+            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
+            float opacity = 1f,
+            float scale = 1f)
+        {
+            canvas.Save();
+
+            canvas.Translate(x, y);
+            if (rotation != 0)
+                canvas.RotateDegrees(rotation, 0, 0);
+            canvas.Scale(scale, scale);
+
+            var width = bitmap.Width;
+            var height = bitmap.Height;
+
+            x = offsetX + DetermineHorizontalAlignmentCorrection(horizontalAlignment, width);
+            y = -offsetY + DetermineVerticalAlignmentCorrection(verticalAlignment, height);
+
+            var halfWidth = width >> 1;
+            var halfHeight = height >> 1;
+
+            var rect = new SKRect(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
+
+            Draw(canvas, bitmap, rect, opacity);
+
+            canvas.Restore();
+        }
+        private static int DetermineHorizontalAlignmentCorrection(
+            LabelStyle.HorizontalAlignmentEnum horizontalAlignment, int width)
+        {
+            if (horizontalAlignment == LabelStyle.HorizontalAlignmentEnum.Left) return width >> 1;
+            if (horizontalAlignment == LabelStyle.HorizontalAlignmentEnum.Right) return -(width >> 1);
+            return 0; // center
+        }
+
+        private static int DetermineVerticalAlignmentCorrection(
+            LabelStyle.VerticalAlignmentEnum verticalAlignment, int height)
+        {
+            if (verticalAlignment == LabelStyle.VerticalAlignmentEnum.Top) return -(height >> 1);
+            if (verticalAlignment == LabelStyle.VerticalAlignmentEnum.Bottom) return height >> 1;
+            return 0; // center
+        }
+
+        private static SKPaint GetPaint(float layerOpacity)
+        {
+            if (Math.Abs(layerOpacity - 1) > Utilities.Constants.Epsilon)
+            {
+                // Unfortunately for opacity we need to set the Color and the Color
+                // is part of the Paint object. So we need to recreate the paint on
+                // every draw. 
+                return new SKPaint
+                {
+                    FilterQuality = SKFilterQuality.Low,
+                    Color = new SKColor(255, 255, 255, (byte)(255 * layerOpacity))
+                };
+            }
+            return DefaultPaint;
+        }
+    }
+}

--- a/Mapsui.Rendering.Skia/ImageStyleRenderer.cs
+++ b/Mapsui.Rendering.Skia/ImageStyleRenderer.cs
@@ -24,14 +24,14 @@ namespace Mapsui.Rendering.Skia
             switch (bitmap.Type)
             {
                 case BitmapType.Bitmap:
-                    BitmapHelper.RenderBitmap(canvas, bitmap.Bitmap,
+                    BitmapRenderer.Draw(canvas, bitmap.Bitmap,
                         (float)destination.X, (float)destination.Y,
                         rotation,
                         (float)offsetX, (float)offsetY,
                         opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
                 case BitmapType.Svg:
-                    BitmapHelper.RenderSvg(canvas, bitmap.Svg,
+                    SvgRenderer.Draw(canvas, bitmap.Svg,
                         (float)destination.X, (float)destination.Y,
                         rotation,
                         (float)offsetX, (float)offsetY,
@@ -45,7 +45,7 @@ namespace Mapsui.Rendering.Skia
                         sprite.Data = bitmapAtlas.Bitmap.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width,
                             sprite.Y + sprite.Height));
                     }
-                    BitmapHelper.RenderBitmap(canvas, (SKImage)sprite.Data,
+                    BitmapRenderer.Draw(canvas, (SKImage)sprite.Data,
                         (float)destination.X, (float)destination.Y,
                         rotation,
                         (float)offsetX, (float)offsetY,

--- a/Mapsui.Rendering.Skia/LabelRenderer.cs
+++ b/Mapsui.Rendering.Skia/LabelRenderer.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Rendering.Skia
             var offsetX = style.Offset.IsRelative ? info.Width * style.Offset.X : style.Offset.X;
             var offsetY = style.Offset.IsRelative ? info.Height * style.Offset.Y : style.Offset.Y;
 
-            BitmapHelper.RenderBitmap(canvas, info.Bitmap, (int)Math.Round(x), (int)Math.Round(y),
+            BitmapRenderer.Draw(canvas, info.Bitmap, (int)Math.Round(x), (int)Math.Round(y),
                 offsetX: (float)offsetX, offsetY: (float)-offsetY,
                 horizontalAlignment: style.HorizontalAlignment, verticalAlignment: style.VerticalAlignment);
         }

--- a/Mapsui.Rendering.Skia/RasterRenderer.cs
+++ b/Mapsui.Rendering.Skia/RasterRenderer.cs
@@ -44,14 +44,14 @@ namespace Mapsui.Rendering.Skia
 
 		            var destination = new BoundingBox(0.0, 0.0, boundingBox.Width, boundingBox.Height);
 
-		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, destination.ToSkia(), opacity);
+                    BitmapRenderer.Draw(canvas, bitmapInfo.Bitmap, destination.ToSkia(), opacity);
 
 		            canvas.SetMatrix(priorMatrix);
 		        }
 		        else
 		        {
 		            var destination = WorldToScreen(viewport, feature.Geometry.BoundingBox);
-		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, RoundToPixel(destination).ToSkia(), opacity);
+		            BitmapRenderer.Draw(canvas, bitmapInfo.Bitmap, RoundToPixel(destination).ToSkia(), opacity);
                 }
 		    }
 			catch (Exception ex)

--- a/Mapsui.Rendering.Skia/SvgRenderer.cs
+++ b/Mapsui.Rendering.Skia/SvgRenderer.cs
@@ -1,0 +1,35 @@
+﻿using Mapsui.Styles;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia
+{
+    public class SvgRenderer
+    {
+        public static void Draw(SKCanvas canvas, SkiaSharp.Extended.Svg.SKSvg svg, float x, float y, float orientation = 0,
+            float offsetX = 0, float offsetY = 0,
+            LabelStyle.HorizontalAlignmentEnum horizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
+            LabelStyle.VerticalAlignmentEnum verticalAlignment = LabelStyle.VerticalAlignmentEnum.Top,
+            float opacity = 1f,
+            float scale = 1f)
+        {
+            // todo: I assume we also need to apply opacity.
+            // todo: It seems horizontalAlignment and verticalAlignment would make sense too. Is this similar to Anchor?
+
+            canvas.Save();
+
+            canvas.Translate(x, y);
+            canvas.RotateDegrees(orientation, 0, 0); // todo: degrees or radians?
+            canvas.Scale(scale, scale);
+
+            var halfWidth = svg.CanvasSize.Width / 2;
+            var halfHeight = svg.CanvasSize.Height / 2;
+
+            // 0/0 are assumed at center of image, but Svg has 0/0 at left top position
+            canvas.Translate(-halfWidth + offsetX, -halfHeight - offsetY);
+
+            canvas.DrawPicture(svg.Picture, new SKPaint() { IsAntialias = true });
+
+            canvas.Restore();
+        }
+    }
+}


### PR DESCRIPTION
Hi there!

This is an experiment. Submitting a pull request to you pull request 🤔

These changes are not directly about what you changed but are related. What triggered me was the BitmapHelper with a RenderSvg method. I now created separate classes, SvgRenderer.Draw, BitmapRenderer.Draw. The intention was to reuse the SvgRenderer.Draw (or overloads) for all the 4 svg rendering calls. The advantage would be that changes like these will be in only one place. I can imagine more common changes, like using Opacity and Anchor. I did not reuse SvgRenderer.Draw  method yet because I am unfamiliar with the other SVG calls. 

Something else that came to mind while working on this is to change the BitmapRegistry into a SymbolImageRegistry that contains objects which have all information available.

